### PR TITLE
Trigger 'loaded' event when slide is loaded.

### DIFF
--- a/deck.lazyload.js
+++ b/deck.lazyload.js
@@ -37,6 +37,7 @@
       $slide.load(url, function(){
 
         $[deck]('.slide');
+        $slide.trigger('loaded');
       });
     }
   }


### PR DESCRIPTION
This may not be the best way of accomplishing this, but I found it useful to trigger a 'loaded' event for each lazyloaded slide.
